### PR TITLE
fix type mismatch error and fix broken functionality

### DIFF
--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -821,7 +821,7 @@ view (Setting settings) =
         viewDropdownMenuItem item =
             button
                 [ class "dropdown__menu-item"
-                , onClick onMenuItemClick
+                , onMouseDown (onMenuItemClick item)
                 ]
                 [ text (settings.toLabel item)
                 ]


### PR DESCRIPTION
## Problem

If someone tries to use the Dropdown component described in the documentation, they will get a compilation error. And after fixing it, the component will still not work correctly: Dropdown will close before the button is pressed.

```elm
        viewDropdownMenuItem : item -> Html msg
        viewDropdownMenuItem item =
            button
                [ class "dropdown__menu-item"
                , onClick onMenuItemClick
                ]
                [ text (settings.toLabel item)
                ]

```

## Solution

Instead of onClick it is better to use onMouseDown, since this event is handled before blur.

```elm
        viewDropdownMenuItem : item -> Html msg
        viewDropdownMenuItem item =
            button
                [ class "dropdown__menu-item"
                , onMouseDown (onMenuItemClick item)
                ]
                [ text (settings.toLabel item)
                ]

```

## Notes
